### PR TITLE
feat!: Use a string-typed ID for collections

### DIFF
--- a/dewy/chunk/models.py
+++ b/dewy/chunk/models.py
@@ -34,7 +34,7 @@ Chunk = Annotated[Union[TextChunk, ImageChunk], Field(discriminator="kind")]
 class RetrieveRequest(BaseModel):
     """A request for retrieving chunks from a collection."""
 
-    collection_id: int
+    collection_id: str
     """The collection to retrieve chunks from."""
 
     query: str

--- a/dewy/chunk/router.py
+++ b/dewy/chunk/router.py
@@ -16,7 +16,7 @@ router = APIRouter(prefix="/chunks")
 async def list_chunks(
     pg_pool: PgPoolDep,
     collection_id: Annotated[
-        int | None, Query(description="Limit to chunks associated with this collection")
+        str | None, Query(description="Limit to chunks associated with this collection")
     ] = None,
     document_id: Annotated[
         int | None, Query(description="Limit to chunks associated with this document")

--- a/dewy/collection/models.py
+++ b/dewy/collection/models.py
@@ -43,9 +43,6 @@ class Collection(BaseModel):
     id: int
     """The ID of the collection."""
 
-    name: str
-    """The name of the collection."""
-
     text_embedding_model: str
     """The name of the embedding model.
 

--- a/dewy/collection/router.py
+++ b/dewy/collection/router.py
@@ -51,14 +51,12 @@ async def add_collection(conn: PgConnectionDep, collection: CollectionCreate) ->
 @router.get("/")
 async def list_collections(
     conn: PgConnectionDep,
-    name: Annotated[str | None, Query(description="Find collections by name.")] = None,
 ) -> List[Collection]:
     """List collections."""
     results = await conn.fetch(
         """
-        SELECT id, name, text_embedding_model
+        SELECT id, text_embedding_model
         FROM collection
-        WHERE name = coalesce($1, name)
         """,
         name,
     )
@@ -73,7 +71,7 @@ async def get_collection(id: PathCollectionId, conn: PgConnectionDep) -> Collect
     """Get a specific collection."""
     result = await conn.fetchrow(
         """
-        SELECT id, name, text_embedding_model
+        SELECT id, text_embedding_model
         FROM collection
         WHERE id = $1
         """,

--- a/dewy/common/collection_embeddings.py
+++ b/dewy/common/collection_embeddings.py
@@ -35,7 +35,7 @@ class CollectionEmbeddings:
         pg_pool: asyncpg.Pool,
         config: Config,
         *,
-        collection_id: int,
+        collection_id: str,
         text_embedding_model: str,
         text_embedding_dimensions: int,
         text_distance_metric: DistanceMetric,
@@ -89,7 +89,7 @@ class CollectionEmbeddings:
 
     @staticmethod
     async def for_collection_id(
-        pg_pool: asyncpg.Pool, config: Config, collection_id: int
+        pg_pool: asyncpg.Pool, config: Config, collection_id: str
     ) -> Self:
         """Retrieve the collection embeddings of the given collection."""
         async with pg_pool.acquire() as conn:
@@ -127,7 +127,6 @@ class CollectionEmbeddings:
             result = await conn.fetchrow(
                 """
                 SELECT
-                    collection.name,
                     collection.id as id,
                     collection.text_embedding_model,
                     collection.text_distance_metric,

--- a/dewy/document/models.py
+++ b/dewy/document/models.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 
 
 class AddDocumentRequest(BaseModel):
-    collection_id: int
+    collection_id: str
     """The id of the collection the document should be added to."""
 
     url: Optional[str] = None
@@ -30,7 +30,7 @@ class Document(BaseModel):
     """Model for documents in Dewy."""
 
     id: Optional[int] = None
-    collection_id: int
+    collection_id: str
 
     extracted_text: Optional[str] = None
     """The text that was extracted for this document.

--- a/dewy/document/router.py
+++ b/dewy/document/router.py
@@ -157,7 +157,7 @@ PathDocumentId = Annotated[int, Path(..., description="The document ID.")]
 async def list_documents(
     conn: PgConnectionDep,
     collection_id: Annotated[
-        int | None,
+        str | None,
         Query(description="Limit to documents associated with this collection"),
     ] = None,
 ) -> List[Document]:

--- a/dewy/frontend/src/Collection.tsx
+++ b/dewy/frontend/src/Collection.tsx
@@ -24,7 +24,7 @@ const ListActions = () => (
 export const CollectionList = () => (
     <List actions={<ListActions/>} >
         <Datagrid>
-            <TextField source="name" />
+            <TextField source="id" />
             <TextField source="text_embedding_model" />
             <TextField source="text_distance_metric" />
             <TextField source="llm_model" />
@@ -49,7 +49,7 @@ export const ChunkingConfig = () => (
 
 const Form = () => (
     <SimpleForm>
-        <TextInput source="name" validate={[required()]} fullWidth />
+        <TextInput source="id" validate={[required()]} fullWidth />
         <SelectInput source="text_embedding_model" defaultValue="hf:BAAI/bge-small-en" choices={[
             {id: 'hf:BAAI/bge-small-en', name: 'BAAI/bge-small-en'},
             {id: 'openai:text-embedding-ada-002', name: 'OpenAI/text_embedding_ada_002'},

--- a/dewy/migrations/0001_schema.sql
+++ b/dewy/migrations/0001_schema.sql
@@ -3,13 +3,11 @@
 CREATE TYPE distance_metric AS ENUM ('cosine', 'l2', 'ip');
 
 CREATE TABLE collection (
-    id SERIAL NOT NULL,
-    name VARCHAR NOT NULL,
+    id VARCHAR NOT NULL,
     text_embedding_model VARCHAR NOT NULL,
     text_distance_metric distance_metric NOT NULL,
 
-    PRIMARY KEY (id),
-    UNIQUE (name)
+    PRIMARY KEY (id)
 );
 
 CREATE TABLE text_embedding_dimensions (
@@ -112,7 +110,7 @@ CREATE TABLE embedding(
 );
 
 -- Default collection
-INSERT INTO collection (name, text_embedding_model, text_distance_metric) VALUES ('main', 'openai:text-embedding-ada-002', 'cosine');
+INSERT INTO collection (id, text_embedding_model, text_distance_metric) VALUES ('main', 'openai:text-embedding-ada-002', 'cosine');
 CREATE INDEX embedding_collection_1_index
 ON embedding
 USING hnsw ((embedding::vector(1536)) vector_cosine_ops)

--- a/example_notebook.ipynb
+++ b/example_notebook.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "response = client.put(f\"/collections/\",\n",
     "                      json = {\n",
-    "                          \"name\": \"my_collection\",\n",
+    "                          \"id\": \"my_collection\",\n",
     "                          \"text_embedding_model\": \"hf:BAAI/bge-small-en\"\n",
     "                      })\n",
     "print(response.json())\n",

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -6,14 +6,12 @@ from dewy_client.models import CollectionCreate
 
 
 async def test_create_collection(client):
-    name = "".join(random.choices(string.ascii_lowercase, k=5))
-    collection = await add_collection.asyncio(client=client, body=CollectionCreate(name=name))
+    id = "".join(random.choices(string.ascii_lowercase, k=5))
+    collection = await add_collection.asyncio(client=client, body=CollectionCreate(id=id))
 
-    assert collection.name == name
+    assert collection.id == id
     assert collection.text_embedding_model == "openai:text-embedding-ada-002"
     assert collection.text_distance_metric == "cosine"
-
-    collection_id = collection.id
 
     list_response = await list_collections.asyncio(client=client)
 
@@ -21,22 +19,23 @@ async def test_create_collection(client):
     # other tests may have created other collections
     collection_row = next(x for x in list_response if x.id == collection_id)
     assert collection_row is not None
-    assert collection_row.name == name
 
-    get_response = await get_collection.asyncio(collection_id, client=client)
+    get_response = await get_collection.asyncio(id, client=client)
 
-    assert get_response.name == name
+    assert get_response.id == id
+    assert get_response.text_embedding_model == "openai:text-embedding-ada-002"
+    assert get_response.text_distance_metric == "cosine"
 
 
 async def test_find_collection(client):
-    name = "".join(random.choices(string.ascii_lowercase, k=5))
+    id = "".join(random.choices(string.ascii_lowercase, k=5))
     collection1 = await add_collection.asyncio(
-        client=client, body=CollectionCreate(name=f"{name}")
+        client=client, body=CollectionCreate(id=f"{id}")
     )
     _collection2 = await add_collection.asyncio(
-        client=client, body=CollectionCreate(name=f"{name}-1")
+        client=client, body=CollectionCreate(id=f"{id}-1")
     )
 
-    list_response = await list_collections.asyncio(name=f"{name}", client=client)
+    list_response = await list_collections.asyncio(id=f"{id}", client=client)
     assert len(list_response) == 1
     assert list_response[0].id == collection1.id

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -31,11 +31,11 @@ SKELETON_OF_THOUGHT_PDF = "https://arxiv.org/pdf/2307.15337.pdf"
 )
 @pytest.mark.timeout(120)  # slow due to embedding (especially in CI)
 async def test_index_retrieval(client, embedding_model):
-    name = "".join(random.choices(string.ascii_lowercase, k=5))
+    id = "".join(random.choices(string.ascii_lowercase, k=5))
 
     collection = await add_collection.asyncio(
         client=client,
-        body=CollectionCreate(name=name, text_embedding_model=embedding_model),
+        body=CollectionCreate(id=id, text_embedding_model=embedding_model),
     )
 
     assert NEARLY_EMPTY_BYTES
@@ -83,11 +83,11 @@ async def test_index_retrieval(client, embedding_model):
 
 
 async def test_ingest_error(client):
-    name = "".join(random.choices(string.ascii_lowercase, k=5))
+    id = "".join(random.choices(string.ascii_lowercase, k=5))
 
     collection = await add_collection.asyncio(
         client=client,
-        body=CollectionCreate(name=name, text_embedding_model="hf:BAAI/bge-small-en"),
+        body=CollectionCreate(id=id, text_embedding_model="hf:BAAI/bge-small-en"),
     )
 
     MESSAGE = "expected-test-failure"


### PR DESCRIPTION
Working with collections is difficult. Most API endpoints currently expect an integer identifier, which the user must find by making an API query.

The point of collections is to provide logical separation between documents, so it's more natural use use descriptive names to identify the collection, ie "cooking-docs" or "prod-env".

This change makes the ID string-typed and user-provided, and drops the "name" field which is now redundant. This is a breaking change - the SQL schema is affected as well as the API types. In theory the "name" field could be promoted to be a new idnetifier through a SQL migration (since it has a unique constraint), but this seems like overkill at this stage.