### PR TITLE
Provide methods to delete documents and collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,11 @@ If you're in a `poetry shell`, you can omit the `poetry run`:
 * Formatting: `poetry run ruff format`
 * Type Checking: `poetry run mypy dewy`
 
+To regenerate the OpenAPI spec and client libraries:
+```sh
+poetry poe extract-openapi
+poetry poe update-client
+```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p
 

--- a/dewy-client/dewy_client/api/kb/delete_collection.py
+++ b/dewy-client/dewy_client/api/kb/delete_collection.py
@@ -1,0 +1,163 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.collection import Collection
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    name: str,
+) -> Dict[str, Any]:
+    _kwargs: Dict[str, Any] = {
+        "method": "delete",
+        "url": f"/api/collections/{name}",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Collection, HTTPValidationError]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = Collection.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Collection, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Collection, HTTPValidationError]]:
+    """Delete Collection
+
+     Delete a collection and all documents contained within it.
+
+    Args:
+        name (str): The collection name.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Collection, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Collection, HTTPValidationError]]:
+    """Delete Collection
+
+     Delete a collection and all documents contained within it.
+
+    Args:
+        name (str): The collection name.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Collection, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        name=name,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Collection, HTTPValidationError]]:
+    """Delete Collection
+
+     Delete a collection and all documents contained within it.
+
+    Args:
+        name (str): The collection name.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Collection, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Collection, HTTPValidationError]]:
+    """Delete Collection
+
+     Delete a collection and all documents contained within it.
+
+    Args:
+        name (str): The collection name.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Collection, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            name=name,
+            client=client,
+        )
+    ).parsed

--- a/dewy-client/dewy_client/api/kb/delete_document.py
+++ b/dewy-client/dewy_client/api/kb/delete_document.py
@@ -1,0 +1,163 @@
+from http import HTTPStatus
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.document import Document
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    id: int,
+) -> Dict[str, Any]:
+    _kwargs: Dict[str, Any] = {
+        "method": "delete",
+        "url": f"/api/documents/{id}",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Document, HTTPValidationError]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = Document.from_dict(response.json())
+
+        return response_200
+    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Document, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Document, HTTPValidationError]]:
+    """Delete Document
+
+     Delete a document.
+
+    Args:
+        id (int): The document ID.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Document, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Document, HTTPValidationError]]:
+    """Delete Document
+
+     Delete a document.
+
+    Args:
+        id (int): The document ID.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Document, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        id=id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Document, HTTPValidationError]]:
+    """Delete Document
+
+     Delete a document.
+
+    Args:
+        id (int): The document ID.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Document, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        id=id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Document, HTTPValidationError]]:
+    """Delete Document
+
+     Delete a document.
+
+    Args:
+        id (int): The document ID.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Document, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            id=id,
+            client=client,
+        )
+    ).parsed

--- a/dewy/collection/router.py
+++ b/dewy/collection/router.py
@@ -1,11 +1,11 @@
 from typing import Annotated, List
 
-from fastapi import APIRouter, HTTPException, Path, status
+from fastapi import APIRouter, HTTPException, Path, status, Response
 from loguru import logger
 
 from dewy.collection.models import Collection, CollectionCreate
 from dewy.common.collection_embeddings import get_dimensions
-from dewy.common.db import PgConnectionDep
+from dewy.common.db import PgConnectionDep, PgPoolDep
 
 router = APIRouter(prefix="/collections")
 
@@ -83,3 +83,60 @@ async def get_collection(name: PathCollection, conn: PgConnectionDep) -> Collect
         )
 
     return Collection.model_validate(dict(result))
+
+@router.delete("/{name}")
+async def delete_collection(pg_pool: PgPoolDep, name: PathCollection) -> Collection:
+    """Delete a collection and all documents contained within it."""
+    async with pg_pool.acquire() as conn:
+        async with conn.transaction():
+            result = await conn.fetchrow(
+                """
+                SELECT id
+                FROM collection
+                WHERE name = $1
+                """,
+                name,
+            )
+
+            if not result:
+                raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=f"No collection with name {name}"
+            )
+            collection_id = result["id"]
+
+            # Delete any embeddings
+            await conn.execute(
+                """
+                DELETE FROM embedding e
+                WHERE collection_id = $1
+                """,
+                collection_id,
+            )
+            # Delete any chunks
+            await conn.execute(
+                """
+                DELETE from chunk c
+                USING document d
+                WHERE c.document_id = d.id
+                AND d.collection_id = $1
+                """,
+                collection_id,
+            )
+            # Delete any documents
+            await conn.execute(
+                """
+                DELETE from document
+                WHERE collection_id = $1
+                """,
+                collection_id,
+            )
+            # Delete the collection
+            await conn.execute(
+                """
+                DELETE from collection
+                WHERE id = $1
+                """,
+                collection_id,
+            )
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -81,6 +81,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - kb
+      summary: Delete Collection
+      description: Delete a collection and all documents contained within it.
+      operationId: deleteCollection
+      parameters:
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          description: The collection name.
+          title: Name
+        description: The collection name.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/documents/:
     post:
       tags:
@@ -181,6 +209,34 @@ paths:
       - kb
       summary: Get Document
       operationId: getDocument
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          description: The document ID.
+          title: Id
+        description: The document ID.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Document'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - kb
+      summary: Delete Document
+      description: Delete a document.
+      operationId: deleteDocument
       parameters:
       - name: id
         in: path

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -11,6 +11,7 @@ from dewy_client.api.kb import (
     add_document,
     get_document,
     get_document_status,
+    delete_document,
     list_chunks,
     list_documents,
     upload_document_content,
@@ -262,3 +263,8 @@ async def test_document_lifecycle(client, doc_fixture):
     original_ids = {c.id for c in chunks}
     new_ids = {c.id for c in chunks2}
     assert original_ids.isdisjoint(new_ids)
+
+    # 5. Verify the document and associated resources can be deleted
+    await delete_document.asyncio(client=client, id=doc_fixture.doc1)
+    chunks3 = await list_chunks.asyncio(client=client, document_id=doc_fixture.doc1)
+    assert not chunks3


### PR DESCRIPTION
Chunks and extracts are managed by the system, so they don't need explicit deletion endpoints - they're deleted whenever the document that produced them is deleted.