### PR TITLE
refactor!: Enumerate supported embeddings

### DIFF
--- a/dewy/collection/models.py
+++ b/dewy/collection/models.py
@@ -1,6 +1,8 @@
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationInfo, field_validator
+
+from dewy.common.embeddings import EMBEDDINGS
 
 
 class DistanceMetric(Enum):
@@ -73,6 +75,14 @@ class CollectionCreate(BaseModel):
 
     NOTE: Changing embedding models is not currently supported.
     """
+
+    @field_validator("text_embedding_model")
+    @classmethod
+    def supported_text_embedding_model(cls, v: str, info: ValidationInfo):
+        assert (
+            v in EMBEDDINGS
+        ), f"{info.field_name} must be one of [{', '.join(EMBEDDINGS.keys())}]"
+        return v
 
     text_distance_metric: DistanceMetric = DistanceMetric.cosine
     """The distance metric to use on the text embedding.

--- a/dewy/collection/router.py
+++ b/dewy/collection/router.py
@@ -1,11 +1,10 @@
 from typing import Annotated, List
 
 from fastapi import APIRouter, HTTPException, Path, Response, status
-from loguru import logger
 
 from dewy.collection.models import Collection, CollectionCreate
-from dewy.common.collection_embeddings import get_dimensions
 from dewy.common.db import PgConnectionDep
+from dewy.common.embeddings import EMBEDDINGS
 
 router = APIRouter(prefix="/collections")
 
@@ -13,8 +12,8 @@ router = APIRouter(prefix="/collections")
 @router.post("/")
 async def add_collection(conn: PgConnectionDep, collection: CollectionCreate) -> Collection:
     """Create a collection."""
-    dimensions = await get_dimensions(conn, collection.text_embedding_model)
-    logger.info("Dimensions: {}", dimensions)
+    dimensions = EMBEDDINGS[collection.text_embedding_model].dimensions
+
     async with conn.transaction():
         result = await conn.fetchrow(
             """

--- a/dewy/common/embeddings.py
+++ b/dewy/common/embeddings.py
@@ -21,8 +21,7 @@ EMBEDDINGS = {
             name="openai:text-embedding-ada-002",
             dimensions=1536,
             factory=lambda config: OpenAIEmbedding(
-                model="text-embedding-ada-002",
-                api_key=config.OPENAI_API_KEY
+                model="text-embedding-ada-002", api_key=config.OPENAI_API_KEY
             ),
         ),
         EmbeddingModel(

--- a/dewy/common/embeddings.py
+++ b/dewy/common/embeddings.py
@@ -1,0 +1,39 @@
+import dataclasses
+from typing import Callable
+
+from llama_index import OpenAIEmbedding
+from llama_index.embeddings import BaseEmbedding, HuggingFaceEmbedding
+
+from dewy.config import Config
+
+
+@dataclasses.dataclass
+class EmbeddingModel:
+    name: str
+    dimensions: int
+    factory: Callable[[Config], BaseEmbedding]
+
+
+EMBEDDINGS = {
+    e.name: e
+    for e in [
+        EmbeddingModel(
+            name="openai:text-embedding-ada-002",
+            dimensions=1536,
+            factory=lambda config: OpenAIEmbedding(
+                model="text-embedding-ada-002",
+                api_key=config.OPENAI_API_KEY
+            ),
+        ),
+        EmbeddingModel(
+            name="hf:BAAI/bge-small-en",
+            dimensions=384,
+            factory=lambda _config: HuggingFaceEmbedding("BAAI/bge-small-en"),
+        ),
+        EmbeddingModel(
+            name="hf:BAAI/bge-small-en-v1.5",
+            dimensions=384,
+            factory=lambda _config: HuggingFaceEmbedding("BAAI/bge-small-en-v1.5"),
+        ),
+    ]
+}

--- a/dewy/document/router.py
+++ b/dewy/document/router.py
@@ -83,9 +83,10 @@ async def add_document(
     background: BackgroundTasks,
     req: AddDocumentRequest,
 ) -> Document:
-    """Add a document from a URL."""
+    """Add a document to a collection."""
     async with pg_pool.acquire() as conn:
         row = None
+        logger.info(f"Request: {req}")
         try:
             row = await conn.fetchrow(
                 """

--- a/dewy/migrations/0001_schema.sql
+++ b/dewy/migrations/0001_schema.sql
@@ -13,22 +13,6 @@ CREATE TABLE collection (
 
 CREATE UNIQUE INDEX ON collection ((lower(name)));
 
-CREATE TABLE text_embedding_dimensions (
-    id SERIAL NOT NULL,
-    name VARCHAR NOT NULL,
-    dimensions INTEGER NOT NULL,
-
-    PRIMARY KEY (id)
-);
-
-CREATE UNIQUE INDEX ON text_embedding_dimensions (name);
-
-INSERT INTO text_embedding_dimensions (name, dimensions)
-VALUES ('openai:text-embedding-ada-002', 1536);
-
-INSERT INTO text_embedding_dimensions (name, dimensions)
-VALUES ('hf:BAAI/bge-small-en', 384);
-
 CREATE TYPE ingest_state AS ENUM ('pending', 'ingested', 'failed');
 CREATE TABLE document(
     id SERIAL NOT NULL,


### PR DESCRIPTION
This is desirable since we may want to use different classes for different models -- for instance, BGE models need a special class to insert prefixes for retrieval. Treating these as hard-coded lets us ensure things are used properly.

We can extend this to support environment based configuration if needed.

This is part of switching to LangChain for extraction+chunking+embedding.