### PR TITLE
feat: Load .env files

### DIFF
--- a/dewy/main.py
+++ b/dewy/main.py
@@ -26,4 +26,7 @@ dewy.add_command(serve)
 dewy.add_command(migrate)
 
 if __name__ == "__main__":
+    from dotenv import load_dotenv
+    load_dotenv()
+
     dewy()

--- a/dewy/main.py
+++ b/dewy/main.py
@@ -27,6 +27,7 @@ dewy.add_command(migrate)
 
 if __name__ == "__main__":
     from dotenv import load_dotenv
+
     load_dotenv()
 
     dewy()

--- a/poetry.lock
+++ b/poetry.lock
@@ -5973,4 +5973,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "5bac7dbf4bff8261206dcc71d577f3078e2b8c430833e11da752882f66f8e988"
+content-hash = "d45c2dc465dceda8f9e02a6fe2132868e259e0764db5cceb87fcaa1e05c0658a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ docx = "^0.2.4"
 taskiq = { version = "^0.11.0", extras = ["cbor"] }
 taskiq-aio-pika = "^0.4.0"
 taskiq-dependencies = "^1.5.1"
+python-dotenv = "^1.0.1"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.3.0"


### PR DESCRIPTION
Load `.env` files before running the Click CLI -- this should populate any defined environment variables before they are parsed. This should close #110.

Alternative solution would be updating the documents, but it seems like the `.env` file is a nice pattern to support.